### PR TITLE
upgrade a127-magic

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1,4 +1,4 @@
-swagger: "2.0"
+swagger: '2.0'
 info:
   version: "0.2.1"
   title: Serenity Challenge API
@@ -57,11 +57,11 @@ paths:
         "200":
           description: Returns a list of all challenge resources
           schema:
-            $ref: ChallengesResponse
+            $ref: '#/definitions/ChallengesResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     post:
       tags:
         - challenges
@@ -74,16 +74,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: ChallengeResource
+            $ref: '#/definitions/ChallengeResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}:
     get:
       tags:
@@ -106,11 +106,11 @@ paths:
         "200":
           description: A full challenge resource
           schema:
-            $ref: ChallengeResponse
+            $ref: '#/definitions/ChallengeResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -128,16 +128,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: ChallengeResource
+            $ref: '#/definitions/ChallengeResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -155,11 +155,11 @@ paths:
         "200":
           description: Challenge was deleted
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/register:
     get:
       tags:
@@ -179,11 +179,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/files:
     post:
       tags:
@@ -205,16 +205,16 @@ paths:
           description:  body of post
           required: true
           schema:
-            $ref: FileResource
+            $ref: '#/definitions/FileResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     get:
       tags:
         - challenges
@@ -238,11 +238,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: FilesResponse
+            $ref: '#/definitions/FilesResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/files/{fileId}:
     get:
       tags:
@@ -273,11 +273,11 @@ paths:
         "200":
           description: Returns a file resource
           schema:
-            $ref: FileResponse
+            $ref: '#/definitions/FileResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -303,16 +303,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: FileResource
+            $ref: '#/definitions/FileResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -338,11 +338,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/participants:
     post:
       tags:
@@ -364,16 +364,16 @@ paths:
           description:  body of post
           required: true
           schema:
-            $ref: ParticipantResource
+            $ref: '#/definitions/ParticipantResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     get:
       tags:
         - challenges
@@ -401,11 +401,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ChallengeParticipantsResponse
+            $ref: '#/definitions/ChallengeParticipantsResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/participants/{participantId}:
     get:
       tags:
@@ -436,11 +436,11 @@ paths:
         "200":
           description: Returns a participant resource
           schema:
-            $ref: ChallengeParticipantResponse
+            $ref: '#/definitions/ChallengeParticipantResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -464,16 +464,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: ParticipantResource
+            $ref: '#/definitions/ParticipantResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -497,11 +497,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/submissions:
     post:
       tags:
@@ -523,16 +523,16 @@ paths:
           description:  body of post
           required: true
           schema:
-            $ref: SubmissionResource
+            $ref: '#/definitions/SubmissionResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     get:
       tags:
         - challenges
@@ -556,11 +556,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ChallengeSubmissionsResponse
+            $ref: '#/definitions/ChallengeSubmissionsResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/submissions/{submissionId}:
     get:
       tags:
@@ -591,11 +591,11 @@ paths:
         "200":
           description: Returns a submission resource
           schema:
-            $ref: ChallengeSubmissionResponse
+            $ref: '#/definitions/ChallengeSubmissionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -619,16 +619,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: SubmissionResource
+            $ref: '#/definitions/SubmissionResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -652,11 +652,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/submissions/{submissionId}/files:
     post:
       tags:
@@ -685,16 +685,16 @@ paths:
           description:  body of post
           required: true
           schema:
-            $ref: FileResource
+            $ref: '#/definitions/FileResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     get:
       tags:
         - challenges
@@ -725,11 +725,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: FilesResponse
+            $ref: '#/definitions/FilesResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/submissions/{submissionId}/files/{fileId}:
     get:
       tags:
@@ -767,11 +767,11 @@ paths:
         "200":
           description: Returns a file resource
           schema:
-            $ref: FileResponse
+            $ref: '#/definitions/FileResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -804,16 +804,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: FileResource
+            $ref: '#/definitions/FileResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -846,11 +846,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/requirements:
     post:
       tags:
@@ -872,16 +872,16 @@ paths:
           description:  body of post
           required: true
           schema:
-            $ref: RequirementResource
+            $ref: '#/definitions/RequirementResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     get:
       tags:
         - challenges
@@ -904,11 +904,11 @@ paths:
         "200":
           description: Array of requirement resources
           schema:
-            $ref: RequirementsResponse
+            $ref: '#/definitions/RequirementsResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/requirements/{requirementId}:
     get:
       tags:
@@ -939,11 +939,11 @@ paths:
         "200":
           description: Returns a requirements resource
           schema:
-            $ref: RequirementResponse
+            $ref: '#/definitions/RequirementResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -969,16 +969,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: RequirementResource
+            $ref: '#/definitions/RequirementResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -1004,11 +1004,11 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/scorecards:
     post:
       tags:
@@ -1030,16 +1030,16 @@ paths:
           description:  body of post
           required: true
           schema:
-            $ref: ScorecardResource
+            $ref: '#/definitions/ScorecardResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     get:
       tags:
         - challenges
@@ -1066,11 +1066,11 @@ paths:
         "200":
           description: Array of scorecard resources
           schema:
-            $ref: ScoreCardsResponse
+            $ref: '#/definitions/ScoreCardsResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/scorecards/{scorecardId}:
     get:
       tags:
@@ -1099,11 +1099,11 @@ paths:
         "200":
           description: A scorecard
           schema:
-            $ref: ScorecardResponse
+            $ref: '#/definitions/ScorecardResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -1127,11 +1127,11 @@ paths:
         "200":
           description: Success, Id of scorecard delete
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -1155,16 +1155,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: ScorecardResource
+            $ref: '#/definitions/ScorecardResource'
       responses:
         "200":
           description: "Success, Id of scorecard updated"
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
 
   /challenges/{challengeId}/scorecards/{scorecardId}/scorecardItems:
     get:
@@ -1194,11 +1194,11 @@ paths:
         "200":
           description: Array of ScorecardItem resources
           schema:
-            $ref: ScorecardItemsResponse
+            $ref: '#/definitions/ScorecardItemsResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     post:
       tags:
         - challenges
@@ -1222,16 +1222,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: ScorecardItemResource
+            $ref: '#/definitions/ScorecardItemResource'
       responses:
         "200":
           description: Success
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/scorecards/{scorecardId}/scorecardItems/{scorecardItemId}:
     get:
       tags:
@@ -1268,11 +1268,11 @@ paths:
         "200":
           description: "Success"
           schema:
-            $ref: ScorecardItemResponse
+            $ref: '#/definitions/ScorecardItemResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     put:
       tags:
         - challenges
@@ -1303,16 +1303,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: ScorecardItemResource
+            $ref: '#/definitions/ScorecardItemResource'
       responses:
         "200":
           description: "Success, scorecard item update id"
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
     delete:
       tags:
         - challenges
@@ -1343,11 +1343,11 @@ paths:
         "200":
           description: "Success, Id of scorecard item"
           schema:
-            $ref: ActionResponse
+            $ref: '#/definitions/ActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/files/{fileId}/download:
     get:
       tags:
@@ -1374,11 +1374,11 @@ paths:
         "200":
           description: "Success"
           schema:
-            $ref: FileActionResponse
+            $ref: '#/definitions/FileActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/files/{fileId}/upload:
     get:
       tags:
@@ -1405,11 +1405,11 @@ paths:
         "200":
           description: "Success"
           schema:
-            $ref: FileActionResponse
+            $ref: '#/definitions/FileActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/submissions/{submissionId}/files/{fileId}/download:
     get:
       tags:
@@ -1443,11 +1443,11 @@ paths:
         "200":
           description: "Success"
           schema:
-            $ref: FileActionResponse
+            $ref: '#/definitions/FileActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
   /challenges/{challengeId}/submissions/{submissionId}/files/{fileId}/upload:
     get:
       tags:
@@ -1481,11 +1481,11 @@ paths:
         "200":
           description: "Success"
           schema:
-            $ref: FileActionResponse
+            $ref: '#/definitions/FileActionResponse'
         default:
           description: Error
           schema:
-            $ref: ErrorResponse
+            $ref: '#/definitions/ErrorResponse'
 # Custom Responses
 definitions:
   ChallengeResource:
@@ -1842,11 +1842,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: ChallengeResource
+          $ref: '#/definitions/ChallengeResource'
           minItems: 0
           uniqueItems: true
   ChallengeResponse:
@@ -1863,9 +1863,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-        $ref: ChallengeResource
+        $ref: '#/definitions/ChallengeResource'
   FileActionResponse:
     required:
       - success
@@ -1880,9 +1880,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-        $ref: FileActionResource
+        $ref: '#/definitions/FileActionResource'
   FileResponse:
     required:
       - success
@@ -1897,9 +1897,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-        $ref: FileResource
+        $ref: '#/definitions/FileResource'
   FilesResponse:
     required:
       - success
@@ -1914,11 +1914,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: FileResource
+          $ref: '#/definitions/FileResource'
           minItems: 0
           uniqueItems: true
   ChallengeParticipantsResponse:
@@ -1935,11 +1935,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: ParticipantResource
+          $ref: '#/definitions/ParticipantResource'
           minItems: 0
           uniqueItems: true
   ChallengeParticipantResponse:
@@ -1956,9 +1956,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-          $ref: ParticipantResource
+          $ref: '#/definitions/ParticipantResource'
   ChallengeSubmissionsResponse:
     required:
       - success
@@ -1973,11 +1973,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: SubmissionResource
+          $ref: '#/definitions/SubmissionResource'
           minItems: 0
           uniqueItems: true
   ChallengeSubmissionResponse:
@@ -1994,9 +1994,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-          $ref: SubmissionResource
+          $ref: '#/definitions/SubmissionResource'
   ScoreCardsResponse:
     required:
       - success
@@ -2011,11 +2011,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: ScorecardResource
+          $ref: '#/definitions/ScorecardResource'
           minItems: 0
           uniqueItems: true
   ScorecardResponse:
@@ -2032,9 +2032,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-        $ref: ScorecardResource
+        $ref: '#/definitions/ScorecardResource'
   ScorecardItemsResponse:
     required:
       - success
@@ -2049,11 +2049,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: ScorecardItemResource
+          $ref: '#/definitions/ScorecardItemResource'
           minItems: 0
           uniqueItems: true
   ScorecardItemResponse:
@@ -2070,9 +2070,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-        $ref: ScorecardItemResource
+        $ref: '#/definitions/ScorecardItemResource'
   ResultsResponse:
     properties:
       success:
@@ -2083,11 +2083,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: ResultResource
+          $ref: '#/definitions/ResultResource'
           minItems: 0
           uniqueItems: true
   RequirementResponse:
@@ -2104,9 +2104,9 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
-        $ref: RequirementResource
+        $ref: '#/definitions/RequirementResource'
   RequirementsResponse:
     required:
       - success
@@ -2121,11 +2121,11 @@ definitions:
         format: int32
         description: The http status code
       metadata:
-        $ref: MetadataListResponse
+        $ref: '#/definitions/MetadataListResponse'
       content:
         type: array
         items:
-          $ref: RequirementResource
+          $ref: '#/definitions/RequirementResource'
           minItems: 0
           uniqueItems: true
   ActionResponse:

--- a/app.js
+++ b/app.js
@@ -23,45 +23,48 @@ var tcUser = require('./lib/tc-auth/tcUser');
 
 var app = express();
 
-app.use(bodyParser.json());
+a127.init(function (swaggerConfig) {
+  app.use(bodyParser.json());
 
 // central point for all authentication
-auth.auth(app);
-app.get('/challenges/:challengeId/register',
-  [jwtCheck.jwtCheck(config.get('auth0')), tcUser.tcUser, routeHelper.requireAuth]);
+  auth.auth(app);
+  app.get('/challenges/:challengeId/register',
+      [jwtCheck.jwtCheck(config.get('auth0')), tcUser.tcUser, routeHelper.requireAuth]);
 
 
 // Serve the Swagger documents and Swagger UI
-if (config.has('app.loadDoc') && config.get('app.loadDoc')) {
-  var swaggerTools = require('swagger-tools');
-  var swaggerUi = swaggerTools.middleware.v2.swaggerUi;
-  var yaml = require('js-yaml');
-  var fs = require('fs');
+  if (config.has('app.loadDoc') && config.get('app.loadDoc')) {
+    var swaggerTools = require('swagger-tools');
+    var swaggerUi = swaggerTools.middleware.v2.swaggerUi;
+    var yaml = require('js-yaml');
+    var fs = require('fs');
 
-  var swaggerDoc = yaml.safeLoad(fs.readFileSync('./api/swagger/swagger.yaml', 'utf8'));
-  app.use(swaggerUi(swaggerDoc));
-}
+    var swaggerDoc = yaml.safeLoad(fs.readFileSync('./api/swagger/swagger.yaml', 'utf8'));
+    app.use(swaggerUi(swaggerDoc));
+  }
 
 
 // @TODO add try/catch logic
-datasource.init(config);
+  datasource.init(config);
 
-var port;
-if (config.has('app.port')) {
-  port = config.get('app.port');
-} else {
-  port = 10010;
-}
+  var port;
+  if (config.has('app.port')) {
+    port = config.get('app.port');
+  } else {
+    port = 10010;
+  }
 
-app.use(partialResponseHelper.parseFields);
+  app.use(partialResponseHelper.parseFields);
 
 // a127 middlewares
-app.use(a127.middleware());
+  app.use(a127.middleware(swaggerConfig));
 // generic error handler
-app.use(routeHelper.errorHandler);
+  app.use(routeHelper.errorHandler);
 // render response data as JSON
-app.use(routeHelper.renderJson);
+  app.use(routeHelper.renderJson);
 
-app.listen(port);
+  app.listen(port);
 
-console.log('app started at ' + port);
+  console.log('app started at ' + port);
+});
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "a127-magic": "^0.6.x",
+    "a127-magic": "^0.7.x",
     "async": "^0.9.0",
     "aws-sdk": "^2.0.29",
     "body-parser": "^1.9.0",

--- a/test/controllers/challenges.js
+++ b/test/controllers/challenges.js
@@ -45,7 +45,7 @@ describe('Challenges Controller', function() {
         title: 'Serenity Challenge',
         status: 'SUBMISSION',
         prizes: [500.00, 250.00],
-        regStartAt: '2014-10-09',
+        regStartAt: '2014-10-09T10:00:00-05:00',
         projectId: 'PROJECT1',
         projectSource: 'TOPCODER'
       };


### PR DESCRIPTION
Hi @indytechcook ,

The 0.7.* version of a127-magic includes a new version of swagger-tools which upgrade to 0.7.4. It has some stricter validations on swagger spec file, especially on the value of $ref. Before that, the value is just a string which equals to Resource name on definition section. Now it must comply a particular format which has a ‘#/definitions/’ prefix .

Another thing is it has a new validation on date-time format now. So in the challenge controller test case, we should change the value of datetime type test data to standard RFC3339 date time. See [swagger spec](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types). 

lovefreya from Topcoder community.